### PR TITLE
docs: update baseline server protocols and add missing variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ This benchmark suite provides:
 | Server | Protocol | Framework |
 |--------|----------|-----------|
 | stdhttp-h1 | HTTP/1.1 | Go standard library |
-| stdhttp-h2 | HTTP/2 (H2C) | `golang.org/x/net/http2` |
-| stdhttp-hybrid | HTTP/1.1 + H2C | Auto-detection |
+| stdhttp-h2 | HTTP/1.1 + H2C | `golang.org/x/net/http2/h2c` |
+| stdhttp-hybrid | HTTP/1.1 + H2C | `golang.org/x/net/http2/h2c` |
 | fiber-h1 | HTTP/1.1 | [Fiber](https://github.com/gofiber/fiber) v2 |
 | gin-h1 | HTTP/1.1 | [Gin](https://github.com/gin-gonic/gin) |
+| gin-h2 | HTTP/1.1 + H2C | Gin + `h2c.NewHandler` |
+| gin-hybrid | HTTP/1.1 + H2C | Gin + `h2c.NewHandler` |
 | chi-h1 | HTTP/1.1 | [Chi](https://github.com/go-chi/chi) |
+| chi-h2 | HTTP/1.1 + H2C | Chi + `h2c.NewHandler` |
+| chi-hybrid | HTTP/1.1 + H2C | Chi + `h2c.NewHandler` |
 | echo-h1 | HTTP/1.1 | [Echo](https://github.com/labstack/echo) |
-| iris-h2 | HTTP/2 (H2C) | [Iris](https://github.com/kataras/iris) |
+| echo-h2 | HTTP/1.1 + H2C | Echo + `h2c.NewHandler` |
+| echo-hybrid | HTTP/1.1 + H2C | Echo + `h2c.NewHandler` |
+| iris-h1 | HTTP/1.1 | [Iris](https://github.com/kataras/iris) |
+| iris-h2 | HTTP/1.1 + H2C | Iris + `h2c.NewHandler` |
+| iris-hybrid | HTTP/1.1 + H2C | Iris + `h2c.NewHandler` |
+
+> **Note**: The `-h2` and `-hybrid` variants use `h2c.NewHandler` which supports both HTTP/1.1 and H2C (HTTP/2 cleartext). The naming reflects the primary benchmark focus: `-h2` for H2C testing, `-hybrid` for mixed protocol testing. Fiber does not support H2C.
 
 ### Theoretical Maximum (Raw Syscalls)
 
@@ -267,8 +277,8 @@ For metal benchmarks, ensure sufficient vCPU quota:
 Request quota increases in AWS Service Quotas for:
 - "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances"
 - "All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests"
-- "Running On-Demand G and VT instances" (for ARM64)
-- "All G and VT Spot Instance Requests" (for ARM64)
+
+> **Note**: Both ARM64 (c6g) and x86 (c5) instances count towards Standard quotas. The "G" in c6g refers to Graviton processors, not GPU instances.
 
 ## Project Structure
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,7 +84,13 @@ func main() {
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown server type: %s\n", *serverType)
 		fmt.Fprintf(os.Stderr, "Available types:\n")
-		fmt.Fprintf(os.Stderr, "  Baseline: stdhttp-h1, stdhttp-h2, stdhttp-hybrid, fiber-h1, iris-h2, gin-h1, chi-h1, echo-h1\n")
+		fmt.Fprintf(os.Stderr, "  Baseline:\n")
+		fmt.Fprintf(os.Stderr, "    stdhttp-h1, stdhttp-h2, stdhttp-hybrid\n")
+		fmt.Fprintf(os.Stderr, "    fiber-h1\n")
+		fmt.Fprintf(os.Stderr, "    gin-h1, gin-h2, gin-hybrid\n")
+		fmt.Fprintf(os.Stderr, "    chi-h1, chi-h2, chi-hybrid\n")
+		fmt.Fprintf(os.Stderr, "    echo-h1, echo-h2, echo-hybrid\n")
+		fmt.Fprintf(os.Stderr, "    iris-h1, iris-h2, iris-hybrid\n")
 		fmt.Fprintf(os.Stderr, "  Theoretical: epoll-h1, epoll-h2, epoll-hybrid, iouring-h1, iouring-h2, iouring-hybrid\n")
 		os.Exit(1)
 	}


### PR DESCRIPTION
- Add all missing server variants (gin-h2, gin-hybrid, chi-h2, chi-hybrid, echo-h2, echo-hybrid, iris-h1, iris-hybrid) to README
- Clarify that -h2 and -hybrid variants use h2c.NewHandler which supports both HTTP/1.1 and H2C protocols
- Fix AWS quota documentation: c6g (Graviton) instances use Standard quota, not G and VT (GPU) quota
- Update server help message to list all available server types

Closes #15