### PR TITLE
Fix metal benchmark: increase client instance sizes and suppress SSM warnings

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -615,9 +615,10 @@ func runBenchmarkWithRetry(ctx context.Context, cfg bench.Config, rc *RemoteCont
 		default:
 		}
 
-		// Refresh server IP from SSM if using dynamic discovery
+		// Refresh server IP from SSM if using dynamic discovery AND we don't have a working IP
 		// This handles the case where a retry server has a different IP
-		if rc.useSSM {
+		// Skip SSM refresh if we already have a valid server IP to avoid warning spam
+		if rc.useSSM && rc.serverIP == "" {
 			if err := rc.refreshServerIP(ctx); err != nil {
 				log.Printf("Warning: Could not refresh server IP from SSM: %v", err)
 			}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -112,17 +112,18 @@ locals {
     }
   }
 
-  # Client instances: modest sizes, always on-demand
+  # Client instances: sized to saturate server, always on-demand
   # Fast mode: very small (just needs to send HTTP requests)
-  # Metal/Provisional mode: 8 vCPU (enough to saturate server)
+  # Metal mode: large enough to saturate bare-metal servers (need ~1/3 server vCPUs)
+  # Provisional mode: 8 vCPU (matches server size)
   client_instance_types = {
     fast = {
       arm64 = "t4g.small"   # 2 vCPU, burstable
       x86   = "t3.small"    # 2 vCPU, burstable
     }
     metal = {
-      arm64 = "c6g.2xlarge" # 8 vCPU
-      x86   = "c5.2xlarge"  # 8 vCPU
+      arm64 = "c6g.4xlarge" # 16 vCPU (to saturate 64 vCPU server)
+      x86   = "c5.9xlarge"  # 36 vCPU (to saturate 96 vCPU server)
     }
     provisional = {
       arm64 = "c6g.2xlarge" # 8 vCPU


### PR DESCRIPTION
## Summary

- Increase client instance sizes for metal mode to properly saturate bare-metal servers
- Fix SSM warning spam during normal benchmark operation

## Problem

The x86 metal benchmark was producing ~38k req/s instead of expected 150k+ req/s because the client instance (c5.2xlarge, 8 vCPU) was too small to saturate the c5.metal server (96 vCPU).

Additionally, SSM Parameter Store warnings were spamming the logs on every benchmark iteration.

## Changes

### 1. Client instance sizes (terraform/variables.tf)

| Arch | Before | After |
|------|--------|-------|
| ARM64 | c6g.2xlarge (8 vCPU) | c6g.4xlarge (16 vCPU) |
| x86 | c5.2xlarge (8 vCPU) | c5.9xlarge (36 vCPU) |

### 2. SSM warning fix (cmd/bench/main.go)

Only refresh server IP from SSM when `rc.serverIP == ""`. This prevents warning spam when the server IP is already known and working.

## Expected Results

| Metric | Before | After |
|--------|--------|-------|
| x86 workers | 32 | 144 |
| x86 connections | 64 | 288 |
| ARM64 workers | 32 | 64 |
| ARM64 connections | 64 | 128 |

## Test plan

- [ ] Run metal benchmark workflow
- [ ] Verify x86 throughput increases significantly (should be 3-4x higher)
- [ ] Verify no SSM warnings during normal operation
- [ ] Verify SSM recovery still works if spot instance is terminated

Fixes #25