### PR TITLE
fix: ensure Go 1.25.5 is used consistently in terraform userdata

### DIFF
--- a/terraform/userdata-client.tftpl
+++ b/terraform/userdata-client.tftpl
@@ -26,9 +26,9 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y -qq curl jq git build-essential linux-tools-generic unzip zip
 
-# Install Go 1.22
+# Install Go 1.25.5
 echo "=== Installing Go ==="
-GO_VERSION="1.22.5"
+GO_VERSION="1.25.5"
 if [ "$ARCHITECTURE" = "arm64" ]; then
     GO_ARCH="arm64"
 else

--- a/terraform/userdata.tftpl
+++ b/terraform/userdata.tftpl
@@ -38,9 +38,9 @@ else
     echo "Warning: Failed to register IP in SSM (may lack IAM permissions - this is optional)"
 fi
 
-# Install Go 1.22
+# Install Go 1.25.5
 echo "=== Installing Go ==="
-GO_VERSION="1.22.5"
+GO_VERSION="1.25.5"
 if [ "$ARCHITECTURE" = "arm64" ]; then
     GO_ARCH="arm64"
 else


### PR DESCRIPTION
## Summary
- Updates Go version from 1.22.5 to 1.25.5 in terraform userdata scripts
- Ensures consistency with the project's Go version requirements

## Changes
- Updated `terraform/userdata.tftpl` to use Go 1.25.5
- Updated `terraform/userdata-client.tftpl` to use Go 1.25.5

## Test Plan
- Ran `make lint` successfully with no issues

Fixes #31