### PR TITLE
fix: pin client and server instances to same availability zone

### DIFF
--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -14,6 +14,7 @@ resource "aws_spot_instance_request" "arm64_server" {
   spot_price             = local.spot_prices[local.effective_mode].arm64
   wait_for_fulfillment   = true
   spot_type              = "one-time"
+  availability_zone      = local.availability_zone
 
   iam_instance_profile   = var.iam_instance_profile_name != "" ? var.iam_instance_profile_name : null
   vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : null
@@ -54,6 +55,7 @@ resource "aws_spot_instance_request" "x86_server" {
   spot_price             = local.spot_prices[local.effective_mode].x86
   wait_for_fulfillment   = true
   spot_type              = "one-time"
+  availability_zone      = local.availability_zone
 
   iam_instance_profile   = var.iam_instance_profile_name != "" ? var.iam_instance_profile_name : null
   vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : null
@@ -89,8 +91,9 @@ resource "aws_spot_instance_request" "x86_server" {
 resource "aws_instance" "arm64_server_ondemand" {
   count = (var.use_on_demand && !var.launch_x86_only && !var.launch_client) ? 1 : 0
 
-  ami           = data.aws_ami.ubuntu_arm64.id
-  instance_type = local.server_instance_types[local.effective_mode].arm64
+  ami               = data.aws_ami.ubuntu_arm64.id
+  instance_type     = local.server_instance_types[local.effective_mode].arm64
+  availability_zone = local.availability_zone
 
   iam_instance_profile   = var.iam_instance_profile_name != "" ? var.iam_instance_profile_name : null
   vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : null
@@ -125,8 +128,9 @@ resource "aws_instance" "arm64_server_ondemand" {
 resource "aws_instance" "x86_server_ondemand" {
   count = (var.use_on_demand && !var.launch_arm64_only && !var.launch_client) ? 1 : 0
 
-  ami           = data.aws_ami.ubuntu_x86.id
-  instance_type = local.server_instance_types[local.effective_mode].x86
+  ami               = data.aws_ami.ubuntu_x86.id
+  instance_type     = local.server_instance_types[local.effective_mode].x86
+  availability_zone = local.availability_zone
 
   iam_instance_profile   = var.iam_instance_profile_name != "" ? var.iam_instance_profile_name : null
   vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : null
@@ -167,8 +171,9 @@ resource "aws_instance" "x86_server_ondemand" {
 resource "aws_instance" "arm64_client" {
   count = (var.launch_client && !var.launch_x86_only) ? 1 : 0
 
-  ami           = data.aws_ami.ubuntu_arm64.id
-  instance_type = local.client_instance_types[local.effective_mode].arm64
+  ami               = data.aws_ami.ubuntu_arm64.id
+  instance_type     = local.client_instance_types[local.effective_mode].arm64
+  availability_zone = local.availability_zone
 
   iam_instance_profile   = var.iam_instance_profile_name != "" ? var.iam_instance_profile_name : null
   vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : null
@@ -204,8 +209,9 @@ resource "aws_instance" "arm64_client" {
 resource "aws_instance" "x86_client" {
   count = (var.launch_client && !var.launch_arm64_only) ? 1 : 0
 
-  ami           = data.aws_ami.ubuntu_x86.id
-  instance_type = local.client_instance_types[local.effective_mode].x86
+  ami               = data.aws_ami.ubuntu_x86.id
+  instance_type     = local.client_instance_types[local.effective_mode].x86
+  availability_zone = local.availability_zone
 
   iam_instance_profile   = var.iam_instance_profile_name != "" ? var.iam_instance_profile_name : null
   vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : null

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -46,10 +46,18 @@ data "aws_caller_identity" "current" {}
 # Get current region
 data "aws_region" "current" {}
 
+# Get available availability zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 # GitHub Actions runner version
 # Hardcoded to avoid GitHub API rate limit issues on shared runner IPs
 # Update periodically from: https://github.com/actions/runner/releases
 # Note: v2.327.1+ required for node24 support (used by actions/checkout@v6)
 locals {
   runner_version = "v2.331.0"
+  # Use first available AZ to ensure client and server are in the same AZ
+  # This reduces cross-AZ latency (~0.5-1ms) that adds noise to benchmarks
+  availability_zone = data.aws_availability_zones.available.names[0]
 }


### PR DESCRIPTION
## Summary
This PR fixes #28 by ensuring that client and server instances are always launched in the same availability zone, eliminating cross-AZ latency that adds ~0.5-1ms of noise to benchmarks.

## Changes
- Added `data.aws_availability_zones` data source to get available AZs
- Added `local.availability_zone` to select the first available AZ consistently
- Added `availability_zone` parameter to all instance resources:
  - `aws_spot_instance_request.arm64_server`
  - `aws_spot_instance_request.x86_server`
  - `aws_instance.arm64_server_ondemand`
  - `aws_instance.x86_server_ondemand`
  - `aws_instance.arm64_client`
  - `aws_instance.x86_client`

## Testing
- Ran `make lint` - no issues
- Terraform syntax is valid

## Impact
- All instances will now launch in the same AZ
- Reduces benchmark latency noise from cross-AZ communication
- No breaking changes - existing infrastructure will continue to work

Fixes #28