### PR TITLE
temp: run x86 benchmarks after ARM64 to stay within vCPU quota

### DIFF
--- a/.github/workflows/benchmark-metal.yml
+++ b/.github/workflows/benchmark-metal.yml
@@ -441,11 +441,14 @@ jobs:
           fi
 
   # Launch x86 infrastructure with independent fallback
+  # TEMPORARY: Run x86 after ARM64 completes to stay within vCPU quota (192 limit)
+  # TODO: Revert to parallel execution once quota increase is approved
+  # Original: needs: [authorize, preflight]
   launch-x86:
     name: Launch x86 Infrastructure
     runs-on: ubuntu-latest
-    needs: [authorize, preflight]
-    if: needs.authorize.outputs.authorized == 'true'
+    needs: [authorize, preflight, cleanup-arm64]
+    if: always() && needs.authorize.outputs.authorized == 'true'
     outputs:
       launched: ${{ steps.result.outputs.launched }}
       is_provisional: ${{ steps.result.outputs.is_provisional }}


### PR DESCRIPTION
## Summary

Temporary workaround for AWS vCPU quota limit (192 vCPUs).

Metal benchmarks need 212 vCPUs total when running in parallel:
- ARM64 server (c6g.metal): 64 vCPUs
- ARM64 client (c6g.4xlarge): 16 vCPUs  
- x86 server (c5.metal): 96 vCPUs
- x86 client (c5.9xlarge): 36 vCPUs

This makes x86 wait for ARM64 cleanup before starting, keeping total vCPU usage under the limit.

## How to Revert

Once the quota increase is approved, revert by changing:

```yaml
# From:
needs: [authorize, preflight, cleanup-arm64]
if: always() && needs.authorize.outputs.authorized == 'true'

# To:
needs: [authorize, preflight]
if: needs.authorize.outputs.authorized == 'true'
```

Or simply revert this commit.

Generated with [Claude Code](https://claude.com/claude-code)