### PR TITLE
feat: add heartbeat support to benchmark servers

### DIFF
--- a/internal/c2/cfn/templates/workers.yaml
+++ b/internal/c2/cfn/templates/workers.yaml
@@ -156,9 +156,12 @@ Resources:
               -H "Content-Type: application/json" \
               -d "{\"run_id\":\"${RunId}\",\"role\":\"server\",\"arch\":\"${Architecture}\",\"instance_id\":\"$INSTANCE_ID\",\"private_ip\":\"$PRIVATE_IP\"}"
 
-            # Start server (control daemon mode)
+            # Start server (control daemon mode with C2 heartbeat)
             echo "Starting server in control mode..."
-            /usr/local/bin/server -mode control -port 8080 -control-port 9999
+            /usr/local/bin/server -mode control -port 8080 -control-port 9999 \
+              -c2-endpoint "${C2Endpoint}" \
+              -run-id "${RunId}" \
+              -arch "${Architecture}"
 
             echo "=== Benchmark Server Exiting ==="
         TagSpecifications:


### PR DESCRIPTION
## Summary
- Add C2 integration flags to server: `-c2-endpoint`, `-run-id`, `-arch`
- Implement C2Client with periodic heartbeat (every 30s) in server
- Send immediate heartbeat on startup so C2 knows server is alive
- Update workers.yaml to pass C2 flags when starting server

## Why
Previously, only clients sent heartbeats to the C2. Servers registered once but never sent updates, so C2 couldn't detect if a server crashed or became unavailable during a benchmark run.

## Test plan
- [ ] Run a benchmark and verify servers show updated `last_seen` timestamps
- [ ] Verify C2 no longer logs "appears unhealthy" warnings for servers