### PR TITLE
fix: add write permissions to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,9 @@ jobs:
     name: Run Benchmark
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    permissions:
+      contents: write
+      pull-requests: write
     if: |
       github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## Summary

- Add explicit `contents: write` permission to allow pushing benchmark results
- Add explicit `pull-requests: write` permission to allow posting PR comments

Fixes #98

## Root Cause

The default `GITHUB_TOKEN` for release events doesn't have write permissions, causing the push to fail with a 403 error after the commit is created.

## Test Plan

- [ ] Re-run a metal benchmark (can use workflow_dispatch with metal mode)
- [ ] Verify results are committed to the repository