### PR TITLE
feat: reduce default benchmark durations

### DIFF
--- a/internal/c2/orchestrator/orchestrator.go
+++ b/internal/c2/orchestrator/orchestrator.go
@@ -29,8 +29,8 @@ const (
 // Default durations per mode
 var DefaultDurations = map[string]string{
 	"fast":  "10s",
-	"med":   "30s",
-	"metal": "60s",
+	"med":   "20s",
+	"metal": "30s",
 }
 
 // Concurrent run limits per mode


### PR DESCRIPTION
## Summary

- Reduce metal mode duration from 60s to 30s
- Reduce med mode duration from 30s to 20s
- Keep fast mode at 10s

This cuts total benchmark runtime in half (from ~90 minutes to ~45 minutes) while maintaining statistically significant results.

**Time savings:**
- Before: 22 servers × 4 benchmarks × 60s = 88 min per arch
- After: 22 servers × 4 benchmarks × 30s = 44 min per arch

30 seconds is still sufficient for reliable benchmark results.

Fixes #97