### PR TITLE
fix: create PR for benchmark results instead of direct push

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -243,7 +243,7 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit Metal Results to Repository
+      - name: Create PR with Benchmark Results
         if: |
           success() &&
           steps.mode.outputs.mode == 'metal' &&
@@ -252,7 +252,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RUN_ID="${{ steps.start.outputs.run_id }}"
-          echo "Committing metal results to repository..."
+          echo "Creating PR with metal results..."
 
           # Restore results from temp location
           cp /tmp/benchmark_results.json results.json
@@ -260,18 +260,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Create branch name with tag and timestamp
+          TAG="${{ github.event.release.tag_name }}"
+          BRANCH="results/${TAG:-manual}-$(date +%Y%m%d%H%M%S)"
+
+          git checkout -b "$BRANCH"
+
           # Determine result paths
           PATHS=("results/latest")
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            TAG="${{ github.event.release.tag_name }}"
             PATHS+=("results/$TAG")
           fi
 
           # Process each architecture
+          ARM64_COUNT=0
+          X86_COUNT=0
           for arch in arm64 x86; do
             ARCH_RESULTS=$(jq -r ".$arch // {}" results.json)
             BENCHMARKS=$(echo "$ARCH_RESULTS" | jq -r '.benchmarks // []')
             COUNT=$(echo "$BENCHMARKS" | jq 'length')
+
+            if [[ "$arch" == "arm64" ]]; then
+              ARM64_COUNT=$COUNT
+            else
+              X86_COUNT=$COUNT
+            fi
 
             if [[ "$COUNT" -gt 0 ]]; then
               for path in "${PATHS[@]}"; do
@@ -301,17 +314,35 @@ jobs:
             fi
           done
 
-          # Commit if there are changes
+          # Commit and push if there are changes
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
             COMMIT_MSG="chore: update benchmark results"
             if [[ "${{ github.event_name }}" == "release" ]]; then
-              COMMIT_MSG="chore: add benchmark results for ${{ github.event.release.tag_name }}"
+              COMMIT_MSG="chore: add benchmark results for $TAG"
             fi
             git commit -m "$COMMIT_MSG"
-            git push
-            echo "Results committed successfully"
+            git push -u origin "$BRANCH"
+
+            # Create PR body with results summary
+            PR_BODY="Automated benchmark results from run \`$RUN_ID\`.
+
+## Results
+- ARM64: $ARM64_COUNT benchmarks
+- x86: $X86_COUNT benchmarks
+
+**Please review the results before merging.**"
+
+            # Create PR (no auto-merge)
+            PR_TITLE="$COMMIT_MSG"
+            PR_URL=$(gh pr create \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY" \
+              --base main)
+
+            echo "::notice::Results PR created: $PR_URL"
+            echo "Results PR created successfully: $PR_URL"
           fi
 
       - name: Post PR Comment with Results


### PR DESCRIPTION
Fixes #112

## Problem
The benchmark workflow attempts to push results directly to main branch, but branch protection rules require changes to go through a pull request:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution
Modified the workflow to create a PR instead of pushing directly. The workflow now:

1. Creates a new branch for the results with naming pattern: `results/{tag}-{timestamp}`
2. Commits the benchmark results to that branch
3. Pushes the branch to origin
4. Creates a PR using `gh pr create`
5. Outputs the PR URL in the workflow logs

## Key Changes
- Renamed step from "Commit Metal Results to Repository" to "Create PR with Benchmark Results"
- Added branch creation: `results/${TAG:-manual}-$(date +%Y%m%d%H%M%S)`
- Changed from `git push` to `git push -u origin "$BRANCH"`
- Added PR creation with summary including:
  - Run ID
  - ARM64 benchmark count
  - x86 benchmark count
  - Review notice
- **No auto-merge** - results must be manually reviewed before merging

## Testing
The YAML syntax has been validated and the workflow structure maintains backward compatibility with existing steps.