### PR TITLE
perf: increase connection count and workers for metal benchmarks

### DIFF
--- a/internal/c2/cfn/templates/workers.yaml
+++ b/internal/c2/cfn/templates/workers.yaml
@@ -442,6 +442,7 @@ Resources:
             /usr/local/bin/bench \
               -mode "${BenchmarkMode}" \
               -duration "${BenchmarkDuration}" \
+              -infra-mode "${Mode}" \
               -server-ip "$SERVER_IP" \
               -control-port 9999 \
               -c2-endpoint "${C2Endpoint}" \


### PR DESCRIPTION
Add infrastructure mode awareness to the benchmark tool for proper scaling based on instance size.

## Problem

Current metal benchmark results show servers not being stressed:
- x86 metal (96 cores) benchmarked with only 288 connections
- Average latency is 0.66ms - server barely working
- Theoretical max: 436k req/s, actual: 215k req/s (client-limited)
- epoll, iouring, and fiber show nearly identical performance because none are stressed

## Solution

Add `-infra-mode` flag to scale connections/workers based on infrastructure:

| Mode | Workers/CPU | Conn/Worker | Max Workers | Max Connections |
|------|-------------|-------------|-------------|-----------------|
| fast | 4 | 2 | 1024 | 4096 |
| med | 8 | 4 | 1024 | 8192 |
| **metal** | **16** | **8** | **2048** | **16384** |

### Example: Metal Mode on c5.9xlarge (36 CPUs)
- Workers: 36 × 16 = 576
- Connections: 576 × 8 = 4,608

vs. previous:
- Workers: 36 × 4 = 144
- Connections: 144 × 2 = 288

## Changes

- `cmd/bench/main.go`: Add `-infra-mode` flag and mode-aware scaling
- `internal/c2/cfn/templates/workers.yaml`: Pass `Mode` parameter to bench tool

## Expected Result

- Server CPU utilization near 100%
- Latency increases to 2-5ms under load (indicating stress)
- Clear performance differentiation between epoll/iouring/fiber

Fixes #100